### PR TITLE
Clean up the binary port code

### DIFF
--- a/execution_engine/src/engine_state/error.rs
+++ b/execution_engine/src/engine_state/error.rs
@@ -4,8 +4,8 @@ use thiserror::Error;
 
 use casper_storage::global_state::{self, state::CommitError};
 use casper_types::{
-    account::AccountHash, bytesrepr, system::mint, ApiError, Digest, Key, KeyTag, PackageHash,
-    ProtocolVersion,
+    account::AccountHash, binary_port, bytesrepr, system::mint, ApiError, Digest, Key, KeyTag,
+    PackageHash, ProtocolVersion,
 };
 
 use crate::{
@@ -159,6 +159,19 @@ impl From<Box<GenesisError>> for Error {
 impl From<stack::RuntimeStackOverflow> for Error {
     fn from(_: stack::RuntimeStackOverflow) -> Self {
         Self::RuntimeStackOverflow
+    }
+}
+
+impl From<Error> for binary_port::ErrorCode {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::RootNotFound(_) => binary_port::ErrorCode::RootNotFound,
+            Error::InvalidDeployItemVariant(_) => binary_port::ErrorCode::InvalidDeployItemVariant,
+            Error::WasmPreprocessing(_) => binary_port::ErrorCode::WasmPreprocessing,
+            Error::InvalidProtocolVersion(_) => binary_port::ErrorCode::InvalidProtocolVersion,
+            Error::Deploy => binary_port::ErrorCode::InvalidDeploy,
+            _ => binary_port::ErrorCode::InternalError,
+        }
     }
 }
 

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -2232,13 +2232,15 @@ where
             .get_keys(&get_all_values_request.key_tag())
             .map_err(|err| Error::Exec(err.into()))?;
 
-        let values: Vec<_> = keys
-            .iter()
-            // TODO[RC]: Do not ignore errors here?
-            .filter_map(|key| tracking_copy.get(key).ok().flatten())
-            .collect();
+        let mut all_values = vec![];
+        for key in keys {
+            if let Some(value) = tracking_copy.get(&key).map_err(Into::into)? {
+                all_values.push(value);
+            }
+        }
+
         Ok(GetAllValuesResult::Success {
-            values: StoredValues(values),
+            values: StoredValues(all_values),
         })
     }
 

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -17,7 +17,8 @@ use casper_types::{
         self, binary_request::BinaryRequest, db_id::DbId, get::GetRequest,
         get_all_values_result::GetAllValuesResult,
         global_state_query_result::GlobalStateQueryResult,
-        non_persistent_data_request::NonPersistedDataRequest, DbRawBytesSpec, NodeStatus,
+        non_persistent_data_request::NonPersistedDataRequest, type_wrappers::ConsensusStatus,
+        DbRawBytesSpec, NodeStatus,
     },
     bytesrepr::{self, FromBytes, ToBytes},
     BinaryResponse, BinaryResponseAndRequest, BlockHashAndHeight, BlockHeader, Peers, Transaction,
@@ -390,8 +391,8 @@ where
                         .await
                         .map(|header| *header.state_root_hash())
                         .unwrap_or_default();
-                    let (our_public_signing_key, round_length) =
-                        consensus_status.map_or((None, None), |(pk, rl)| (Some(pk), rl));
+                    let (our_public_signing_key, round_length) = consensus_status
+                        .map_or((None, None), |ConsensusStatus((pk, rl))| (Some(pk), rl));
 
                     let status = NodeStatus {
                         peers: Peers::from(peers),

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -401,9 +401,9 @@ where
 {
     match req {
         NonPersistedDataRequest::BlockHeight2Hash { height } => {
-            BinaryResponse::from_opt(effect_builder.get_block_hash_for_height(height).await)
+            BinaryResponse::from_value(effect_builder.get_block_hash_for_height(height).await)
         }
-        NonPersistedDataRequest::HighestCompleteBlock => BinaryResponse::from_opt(
+        NonPersistedDataRequest::HighestCompleteBlock => BinaryResponse::from_value(
             effect_builder
                 .get_highest_complete_block_header_from_storage()
                 .await
@@ -419,7 +419,7 @@ where
             )
         }
         NonPersistedDataRequest::TransactionHash2BlockHashAndHeight { transaction_hash } => {
-            BinaryResponse::from_opt(
+            BinaryResponse::from_value(
                 effect_builder
                     .get_block_hash_and_height_for_transaction(transaction_hash)
                     .await,
@@ -452,10 +452,10 @@ where
                 .await,
         ),
         NonPersistedDataRequest::NextUpgrade => {
-            BinaryResponse::from_opt(effect_builder.get_next_upgrade().await)
+            BinaryResponse::from_value(effect_builder.get_next_upgrade().await)
         }
         NonPersistedDataRequest::ConsensusStatus => {
-            BinaryResponse::from_opt(effect_builder.consensus_status().await)
+            BinaryResponse::from_value(effect_builder.consensus_status().await)
         }
         NonPersistedDataRequest::ChainspecRawBytes => {
             BinaryResponse::from_value((*effect_builder.get_chainspec_raw_bytes().await).clone())
@@ -641,7 +641,6 @@ async fn handle_client<REv>(
     drop(permit);
 }
 
-// TODO[RC]: Move to Self::
 async fn run_server<REv>(effect_builder: EffectBuilder<REv>, config: Arc<Config>)
 where
     REv: From<Event>
@@ -670,11 +669,11 @@ where
                         .await;
                 }
                 Err(io_err) => {
-                    println!("acceptance failure: {:?}", io_err);
+                    info!(%io_err, "problem accepting binary port connection");
                 }
             }
         },
-        Err(_) => todo!(), // TODO[RC]: Handle this
+        Err(err) => error!(%err, "unable to bind binary port listener"),
     };
 }
 

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -31,9 +31,10 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tracing::{debug, error, info, trace, warn};
 
 use casper_types::{
-    binary_port::type_wrappers::ConsensusValidatorChanges, AsymmetricType, BlockHash, BlockHeader,
-    Chainspec, ConsensusProtocolName, Digest, DisplayIter, EraId, FinalizedApprovals, PublicKey,
-    RewardedSignatures, TimeDiff, Timestamp, Transaction, TransactionHash, ValidatorChange,
+    binary_port::type_wrappers::{ConsensusStatus, ConsensusValidatorChanges},
+    AsymmetricType, BlockHash, BlockHeader, Chainspec, ConsensusProtocolName, Digest, DisplayIter,
+    EraId, FinalizedApprovals, PublicKey, RewardedSignatures, Timestamp, Transaction,
+    TransactionHash, ValidatorChange,
 };
 
 use crate::{
@@ -1281,17 +1282,16 @@ impl EraSupervisor {
         }
     }
 
-    pub(super) fn status(
-        &self,
-        responder: Responder<Option<(PublicKey, Option<TimeDiff>)>>,
-    ) -> Effects<Event> {
+    pub(super) fn status(&self, responder: Responder<Option<ConsensusStatus>>) -> Effects<Event> {
         let public_key = self.validator_matrix.public_signing_key().clone();
         let round_length = self
             .open_eras
             .values()
             .last()
             .and_then(|era| era.consensus.next_round_length());
-        responder.respond(Some((public_key, round_length))).ignore()
+        responder
+            .respond(Some(ConsensusStatus((public_key, round_length))))
+            .ignore()
     }
 
     /// Get a reference to the era supervisor's open eras.

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -385,7 +385,6 @@ impl Storage {
             Box::new(block_body_dbs),
             Box::new(block_metadata_db),
         ];
-        // x.push(block_body_dbs);
 
         let mut db_mapper: HashMap<DbId, Box<dyn RawDataAccess>> = HashMap::new();
         db_mapper.insert(DbId::Transaction, Box::new(transaction_dbs));

--- a/node/src/components/storage/versioned_databases.rs
+++ b/node/src/components/storage/versioned_databases.rs
@@ -179,7 +179,6 @@ where
             .map(Into::into))
     }
 
-    // TODO[RC]: Replace returned tuple with proper struct (bool = is_legacy)
     pub(super) fn get_raw(
         &self,
         txn: &RoTransaction,

--- a/node/src/components/transaction_acceptor/error.rs
+++ b/node/src/components/transaction_acceptor/error.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 use thiserror::Error;
 
 use casper_types::{
-    AddressableEntityHash, BlockHash, BlockHeader, DeployConfigFailure, Digest, EntityVersion,
-    InitiatorAddr, PackageHash, Timestamp, TransactionV1ConfigFailure,
+    binary_port, AddressableEntityHash, BlockHash, BlockHeader, DeployConfigFailure, Digest,
+    EntityVersion, InitiatorAddr, PackageHash, Timestamp, TransactionV1ConfigFailure,
 };
 
 // `allow` can be removed once https://github.com/casper-network/casper-node/issues/3063 is fixed.
@@ -64,6 +64,20 @@ impl Error {
             block_hash: block_header.block_hash(),
             block_height: block_header.height(),
             failure,
+        }
+    }
+}
+
+impl From<Error> for binary_port::ErrorCode {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::EmptyBlockchain
+            | Error::InvalidDeployConfiguration(_)
+            | Error::InvalidV1Configuration(_)
+            | Error::Parameters { .. }
+            | Error::Expired { .. }
+            | Error::ExpectedDeploy
+            | Error::ExpectedTransactionV1 => binary_port::ErrorCode::InvalidDeploy,
         }
     }
 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -125,8 +125,8 @@ use casper_types::{
         db_id::DbId,
         get_all_values_result::GetAllValuesResult,
         type_wrappers::{
-            ConsensusValidatorChanges, GetTrieFullResult, HighestBlockSequenceCheckResult,
-            LastProgress, NetworkName, SpeculativeExecutionResult,
+            ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult,
+            HighestBlockSequenceCheckResult, LastProgress, NetworkName, SpeculativeExecutionResult,
         },
         DbRawBytesSpec,
     },
@@ -136,8 +136,8 @@ use casper_types::{
     AddressableEntity, AvailableBlockRange, Block, BlockHash, BlockHashAndHeight, BlockHeader,
     BlockIdentifier, BlockSignatures, BlockSynchronizerStatus, BlockV2, ChainspecRawBytes,
     DeployHash, DeployHeader, Digest, EraId, FinalitySignature, FinalitySignatureId,
-    FinalizedApprovals, Key, NextUpgrade, PublicKey, ReactorState, TimeDiff, Timestamp,
-    Transaction, TransactionHash, TransactionId, Transfer, Uptime, U512,
+    FinalizedApprovals, Key, NextUpgrade, PublicKey, ReactorState, Timestamp, Transaction,
+    TransactionHash, TransactionId, Transfer, Uptime, U512,
 };
 
 use crate::{
@@ -2136,8 +2136,7 @@ impl<REv> EffectBuilder<REv> {
     }
 
     /// Get our public key from consensus, and if we're a validator, the next round length.
-    // TODO[RC]: Turn the return type into `ConsensusStatus`
-    pub(crate) async fn consensus_status(self) -> Option<(PublicKey, Option<TimeDiff>)>
+    pub(crate) async fn consensus_status(self) -> Option<ConsensusStatus>
     where
         REv: From<ConsensusRequest>,
     {

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -31,8 +31,8 @@ use casper_types::{
         db_id::DbId,
         get_all_values_result::GetAllValuesResult,
         type_wrappers::{
-            ConsensusValidatorChanges, GetTrieFullResult, HighestBlockSequenceCheckResult,
-            LastProgress, NetworkName, SpeculativeExecutionResult,
+            ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult,
+            HighestBlockSequenceCheckResult, LastProgress, NetworkName, SpeculativeExecutionResult,
         },
         DbRawBytesSpec,
     },
@@ -41,8 +41,8 @@ use casper_types::{
     AvailableBlockRange, Block, BlockHash, BlockHashAndHeight, BlockHeader, BlockIdentifier,
     BlockSignatures, BlockSynchronizerStatus, BlockV2, ChainspecRawBytes, DeployHash, DeployHeader,
     Digest, DisplayIter, EraId, FinalitySignature, FinalitySignatureId, FinalizedApprovals, Key,
-    NextUpgrade, PublicKey, ReactorState, TimeDiff, Timestamp, Transaction, TransactionHash,
-    TransactionId, Transfer, Uptime, U512,
+    NextUpgrade, PublicKey, ReactorState, Timestamp, Transaction, TransactionHash, TransactionId,
+    Transfer, Uptime, U512,
 };
 
 use super::{AutoClosingResponder, GossipTarget, Responder};
@@ -1046,7 +1046,7 @@ type BlockHeight = u64;
 /// Consensus component requests.
 pub(crate) enum ConsensusRequest {
     /// Request for our public key, and if we're a validator, the next round length.
-    Status(Responder<Option<(PublicKey, Option<TimeDiff>)>>),
+    Status(Responder<Option<ConsensusStatus>>),
     /// Request for a list of validator status changes, by public key.
     ValidatorChanges(Responder<ConsensusValidatorChanges>),
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -820,7 +820,6 @@ pub(crate) enum ContractRuntimeRequest {
         responder: Responder<Result<EraValidators, GetEraValidatorsError>>,
     },
     /// Return all values at a given state root hash and given key tag.
-    // TODO[RC]: Reconsider this - could be attackable.
     GetAllValues {
         /// Get all values request.
         #[serde(skip_serializing)]

--- a/node/src/types/status_feed.rs
+++ b/node/src/types/status_feed.rs
@@ -9,8 +9,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::{
-    ActivationPoint, AvailableBlockRange, Block, BlockHash, BlockSynchronizerStatus, Digest, EraId,
-    NextUpgrade, Peers, ProtocolVersion, PublicKey, ReactorState, TimeDiff, Timestamp,
+    binary_port::type_wrappers::ConsensusStatus, ActivationPoint, AvailableBlockRange, Block,
+    BlockHash, BlockSynchronizerStatus, Digest, EraId, NextUpgrade, Peers, ProtocolVersion,
+    PublicKey, ReactorState, TimeDiff, Timestamp,
 };
 
 use crate::{
@@ -109,7 +110,7 @@ impl StatusFeed {
         last_added_block: Option<Block>,
         peers: BTreeMap<NodeId, String>,
         chainspec_info: ChainspecInfo,
-        consensus_status: Option<(PublicKey, Option<TimeDiff>)>,
+        consensus_status: Option<ConsensusStatus>,
         node_uptime: Duration,
         reactor_state: ReactorState,
         last_progress: Timestamp,
@@ -117,10 +118,8 @@ impl StatusFeed {
         block_sync: BlockSynchronizerStatus,
         starting_state_root_hash: Digest,
     ) -> Self {
-        let (our_public_signing_key, round_length) = match consensus_status {
-            Some((public_key, round_length)) => (Some(public_key), round_length),
-            None => (None, None),
-        };
+        let (our_public_signing_key, round_length) =
+            consensus_status.map_or((None, None), |ConsensusStatus((pk, rl))| (Some(pk), rl));
         StatusFeed {
             last_added_block,
             peers,

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -6279,7 +6279,7 @@
         "additionalProperties": false
       },
       "MinimalBlockInfo": {
-        "description": "Minimal info of a `Block`.",
+        "description": "Minimal info about a `Block` needed to satisfy the node status request.",
         "type": "object",
         "required": [
           "creator",

--- a/resources/test/schema_status.json
+++ b/resources/test/schema_status.json
@@ -162,7 +162,7 @@
       "type": "string"
     },
     "MinimalBlockInfo": {
-      "description": "Minimal info of a `Block`.",
+      "description": "Minimal info about a `Block` needed to satisfy the node status request.",
       "type": "object",
       "required": [
         "creator",

--- a/types/src/binary_port/binary_request.rs
+++ b/types/src/binary_port/binary_request.rs
@@ -19,9 +19,7 @@ const TRY_ACCEPT_TRANSACTION_TAG: u8 = 1;
 const SPECULATIVE_EXEC_TAG: u8 = 2;
 
 /// A request to the binary access interface.
-// TODO[RC] Add version tag, or rather follow the `BinaryRequestV1/V2` scheme.
-// TODO[RC] Remove clone
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum BinaryRequest {
     /// Request to get data from the node
     Get(GetRequest),

--- a/types/src/binary_port/binary_response.rs
+++ b/types/src/binary_port/binary_response.rs
@@ -56,7 +56,6 @@ impl BinaryResponse {
         }
     }
 
-    // TODO[RC]: Can we prevent V from being an Option here?
     /// Creates a new binary response from a value.
     pub fn from_value<V>(val: V) -> Self
     where
@@ -66,21 +65,6 @@ impl BinaryResponse {
         BinaryResponse {
             payload: ToBytes::to_bytes(&val).unwrap(),
             header: BinaryResponseHeader::new(Some(val.into())),
-        }
-    }
-
-    /// Creates a new binary response from an optional value.
-    pub fn from_opt<V>(val: Option<V>) -> Self
-    where
-        V: ToBytes,
-        V: Into<PayloadType>,
-    {
-        match val {
-            Some(val) => Self::from_value(val),
-            None => BinaryResponse {
-                payload: vec![],
-                header: BinaryResponseHeader::new_error(ErrorCode::NotFound),
-            },
         }
     }
 

--- a/types/src/binary_port/error_code.rs
+++ b/types/src/binary_port/error_code.rs
@@ -13,35 +13,33 @@ pub enum ErrorCode {
     /// This function is disabled.
     #[cfg_attr(feature = "std", error("this function is disabled"))]
     FunctionIsDisabled = 1,
-    //    #[cfg_attr(feature = "std", error("request cannot be decoded"))]
-    //    InvalidRequest = 2, // TODO[RC]: handle this
     /// Data not found.
     #[cfg_attr(feature = "std", error("data not found"))]
-    NotFound = 3,
+    NotFound = 2,
     /// Root not found.
     #[cfg_attr(feature = "std", error("root not found"))]
-    RootNotFound = 4,
+    RootNotFound = 3,
     /// Invalid deploy item variant.
     #[cfg_attr(feature = "std", error("invalid deploy item variant"))]
-    InvalidDeployItemVariant = 5,
+    InvalidDeployItemVariant = 4,
     /// Wasm preprocessing.
     #[cfg_attr(feature = "std", error("wasm preprocessing"))]
-    WasmPreprocessing = 6,
+    WasmPreprocessing = 5,
     /// Invalid protocol version.
     #[cfg_attr(feature = "std", error("invalid protocol version"))]
-    InvalidProtocolVersion = 7,
+    InvalidProtocolVersion = 6,
     /// Invalid deploy.
     #[cfg_attr(feature = "std", error("invalid deploy"))]
-    InvalidDeploy = 8,
+    InvalidDeploy = 7,
     /// Internal error.
     #[cfg_attr(feature = "std", error("internal error"))]
-    InternalError = 9,
+    InternalError = 8,
     /// The query to global state failed.
     #[cfg_attr(feature = "std", error("the query to global state failed"))]
-    QueryFailedToExecute = 10,
+    QueryFailedToExecute = 9,
     /// Bad request.
     #[cfg_attr(feature = "std", error("bad request"))]
-    BadRequest = 11,
+    BadRequest = 10,
 }
 
 impl TryFrom<u8> for ErrorCode {

--- a/types/src/binary_port/non_persistent_data_request.rs
+++ b/types/src/binary_port/non_persistent_data_request.rs
@@ -58,7 +58,6 @@ pub enum NonPersistedDataRequest {
     /// Returns current state of the main reactor.
     ReactorState,
     /// Returns current network name.
-    // TODO[RC]: Consider "generic" get chainspec param? Or just "get_chainspec"?
     NetworkName,
     /// Returns consensus validator changes.
     ConsensusValidatorChanges,

--- a/types/src/binary_port/payload_type.rs
+++ b/types/src/binary_port/payload_type.rs
@@ -14,16 +14,17 @@ use crate::testing::TestRng;
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    AvailableBlockRange, BlockHash, BlockHashAndHeight, BlockSynchronizerStatus, Peers, PublicKey,
-    ReactorState, TimeDiff, Uptime,
+    AvailableBlockRange, BlockHash, BlockHashAndHeight, BlockSynchronizerStatus, Peers,
+    ReactorState, Uptime,
 };
 
 use super::{
     db_id::DbId,
     global_state_query_result::GlobalStateQueryResult,
     type_wrappers::{
-        ConsensusValidatorChanges, GetTrieFullResult, HighestBlockSequenceCheckResult,
-        LastProgress, NetworkName, SpeculativeExecutionResult, StoredValues,
+        ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult,
+        HighestBlockSequenceCheckResult, LastProgress, NetworkName, SpeculativeExecutionResult,
+        StoredValues,
     },
 };
 
@@ -186,6 +187,7 @@ impl TryFrom<u8> for PayloadType {
             }
             x if x == PayloadType::StoredValues as u8 => Ok(PayloadType::StoredValues),
             x if x == PayloadType::GetTrieFullResult as u8 => Ok(PayloadType::GetTrieFullResult),
+            x if x == PayloadType::NodeStatus as u8 => Ok(PayloadType::NodeStatus),
             _ => Err(()),
         }
     }
@@ -301,8 +303,8 @@ impl From<crate::NextUpgrade> for PayloadType {
     }
 }
 
-impl From<(PublicKey, Option<TimeDiff>)> for PayloadType {
-    fn from(_: (PublicKey, Option<TimeDiff>)) -> Self {
+impl From<ConsensusStatus> for PayloadType {
+    fn from(_: ConsensusStatus) -> Self {
         Self::ConsensusStatus
     }
 }

--- a/types/src/binary_port/payload_type.rs
+++ b/types/src/binary_port/payload_type.rs
@@ -44,7 +44,7 @@ pub enum PayloadType {
     /// Legacy version of the approvals hashes.
     ApprovalsHashesV1,
     /// Approvals hashes
-    ApprovalsHashes, // TODO[RC]: not existing yet
+    ApprovalsHashes,
     /// Block signatures.
     BlockSignatures,
     /// Deploy.

--- a/types/src/binary_port/payload_type.rs
+++ b/types/src/binary_port/payload_type.rs
@@ -58,8 +58,7 @@ pub enum PayloadType {
     /// Transfers.
     VecTransfers,
     /// Global state bytes.
-    // TODO[RC]: Needs wrapper.
-    VecU8,
+    StateStoreValue,
     /// Finalized deploy approvals.
     FinalizedDeployApprovals,
     /// Finalized approvals.
@@ -114,7 +113,7 @@ impl PayloadType {
             (true, DbId::Transaction) => Self::Deploy,
             (true, DbId::ExecutionResult) => Self::ExecutionResultV1,
             (true, DbId::Transfer) => Self::VecTransfers,
-            (true, DbId::StateStore) => Self::VecU8,
+            (true, DbId::StateStore) => Self::StateStoreValue,
             (true, DbId::FinalizedTransactionApprovals) => Self::FinalizedDeployApprovals,
             (false, DbId::BlockHeader) => Self::BlockHeader,
             (false, DbId::BlockBody) => Self::BlockBody,
@@ -123,7 +122,7 @@ impl PayloadType {
             (false, DbId::Transaction) => Self::Transaction,
             (false, DbId::ExecutionResult) => Self::ExecutionResult,
             (false, DbId::Transfer) => Self::VecTransfers,
-            (false, DbId::StateStore) => Self::VecU8,
+            (false, DbId::StateStore) => Self::StateStoreValue,
             (false, DbId::FinalizedTransactionApprovals) => Self::FinalizedApprovals,
         }
     }
@@ -152,7 +151,7 @@ impl TryFrom<u8> for PayloadType {
             x if x == PayloadType::ExecutionResultV1 as u8 => Ok(PayloadType::ExecutionResultV1),
             x if x == PayloadType::ExecutionResult as u8 => Ok(PayloadType::ExecutionResult),
             x if x == PayloadType::VecTransfers as u8 => Ok(PayloadType::VecTransfers),
-            x if x == PayloadType::VecU8 as u8 => Ok(PayloadType::VecU8),
+            x if x == PayloadType::StateStoreValue as u8 => Ok(PayloadType::StateStoreValue),
             x if x == PayloadType::FinalizedDeployApprovals as u8 => {
                 Ok(PayloadType::FinalizedDeployApprovals)
             }
@@ -208,7 +207,7 @@ impl fmt::Display for PayloadType {
             PayloadType::ExecutionResultV1 => write!(f, "ExecutionResultV1"),
             PayloadType::ExecutionResult => write!(f, "ExecutionResult"),
             PayloadType::VecTransfers => write!(f, "VecTransfers"),
-            PayloadType::VecU8 => write!(f, "VecU8"),
+            PayloadType::StateStoreValue => write!(f, "StateStoreValue"),
             PayloadType::FinalizedDeployApprovals => write!(f, "FinalizedDeployApprovals"),
             PayloadType::FinalizedApprovals => write!(f, "FinalizedApprovals"),
             PayloadType::BlockHashAndHeight => write!(f, "BlockHashAndHeight"),
@@ -371,7 +370,7 @@ const TRANSACTION_TAG: u8 = 8;
 const EXECUTION_RESULT_V1_TAG: u8 = 9;
 const EXECUTION_RESULT_TAG: u8 = 10;
 const VEC_TRANSFERS_TAG: u8 = 11;
-const VEC_U8_TAG: u8 = 12;
+const STATE_STORE_VALUE_TAG: u8 = 12;
 const FINALIZED_DEPLOY_APPROVALS_TAG: u8 = 13;
 const FINALIZED_APPROVALS_TAG: u8 = 14;
 const BLOCK_HASH_AND_HEIGHT_TAG: u8 = 15;
@@ -415,7 +414,7 @@ impl ToBytes for PayloadType {
             PayloadType::ExecutionResultV1 => EXECUTION_RESULT_V1_TAG,
             PayloadType::ExecutionResult => EXECUTION_RESULT_TAG,
             PayloadType::VecTransfers => VEC_TRANSFERS_TAG,
-            PayloadType::VecU8 => VEC_U8_TAG,
+            PayloadType::StateStoreValue => STATE_STORE_VALUE_TAG,
             PayloadType::FinalizedDeployApprovals => FINALIZED_DEPLOY_APPROVALS_TAG,
             PayloadType::FinalizedApprovals => FINALIZED_APPROVALS_TAG,
             PayloadType::BlockHashAndHeight => BLOCK_HASH_AND_HEIGHT_TAG,
@@ -462,7 +461,7 @@ impl FromBytes for PayloadType {
             EXECUTION_RESULT_V1_TAG => PayloadType::ExecutionResultV1,
             EXECUTION_RESULT_TAG => PayloadType::ExecutionResult,
             VEC_TRANSFERS_TAG => PayloadType::VecTransfers,
-            VEC_U8_TAG => PayloadType::VecU8,
+            STATE_STORE_VALUE_TAG => PayloadType::StateStoreValue,
             FINALIZED_DEPLOY_APPROVALS_TAG => PayloadType::FinalizedDeployApprovals,
             FINALIZED_APPROVALS_TAG => PayloadType::FinalizedApprovals,
             BLOCK_HASH_AND_HEIGHT_TAG => PayloadType::BlockHashAndHeight,

--- a/types/src/binary_port/type_wrappers.rs
+++ b/types/src/binary_port/type_wrappers.rs
@@ -129,6 +129,17 @@ impl StoredValues {
     }
 }
 
+/// Describes the consensus status
+#[derive(Debug, PartialEq)]
+pub struct ConsensusStatus(pub (PublicKey, Option<TimeDiff>));
+
+impl ConsensusStatus {
+    /// Returns the inner value.
+    pub fn into_inner(self) -> (PublicKey, Option<TimeDiff>) {
+        self.0
+    }
+}
+
 impl_bytesrepr_for_type_wrapper!(Uptime);
 impl_bytesrepr_for_type_wrapper!(ConsensusValidatorChanges);
 impl_bytesrepr_for_type_wrapper!(NetworkName);
@@ -137,3 +148,4 @@ impl_bytesrepr_for_type_wrapper!(HighestBlockSequenceCheckResult);
 impl_bytesrepr_for_type_wrapper!(SpeculativeExecutionResult);
 impl_bytesrepr_for_type_wrapper!(GetTrieFullResult);
 impl_bytesrepr_for_type_wrapper!(StoredValues);
+impl_bytesrepr_for_type_wrapper!(ConsensusStatus);

--- a/types/src/binary_port/type_wrappers.rs
+++ b/types/src/binary_port/type_wrappers.rs
@@ -129,13 +129,24 @@ impl StoredValues {
     }
 }
 
-/// Describes the consensus status
+/// Describes the consensus status.
 #[derive(Debug, PartialEq)]
 pub struct ConsensusStatus(pub (PublicKey, Option<TimeDiff>));
 
 impl ConsensusStatus {
     /// Returns the inner value.
     pub fn into_inner(self) -> (PublicKey, Option<TimeDiff>) {
+        self.0
+    }
+}
+
+/// Type representing bytes from the state store db.
+#[derive(Debug, PartialEq)]
+pub struct StateStoreValue(pub Vec<u8>);
+
+impl StateStoreValue {
+    /// Returns the inner value.
+    pub fn into_inner(self) -> Vec<u8> {
         self.0
     }
 }
@@ -149,3 +160,4 @@ impl_bytesrepr_for_type_wrapper!(SpeculativeExecutionResult);
 impl_bytesrepr_for_type_wrapper!(GetTrieFullResult);
 impl_bytesrepr_for_type_wrapper!(StoredValues);
 impl_bytesrepr_for_type_wrapper!(ConsensusStatus);
+impl_bytesrepr_for_type_wrapper!(StateStoreValue);


### PR DESCRIPTION
This PR cleans-up some parts of the binary port code, removes unwraps(), panics() and stray code/comments.