### PR TITLE
binary_port: Restrict access to `legacy` and `current` database fields

### DIFF
--- a/node/src/components/storage/versioned_databases.rs
+++ b/node/src/components/storage/versioned_databases.rs
@@ -117,11 +117,11 @@ pub(super) struct VersionedDatabases<K, V> {
     /// Legacy form of the data, with the key as `K::Legacy` type (converted to bytes using
     /// `AsRef<[u8]>`) and the value bincode-encoded.
     #[data_size(skip)]
-    pub legacy: Database,
+    legacy: Database,
     /// Current form of the data, with the key as `K` bytesrepr-encoded and the value as `V` also
     /// bytesrepr-encoded.
     #[data_size(skip)]
-    pub current: Database,
+    current: Database,
     _phantom: PhantomData<(K, V)>,
 }
 


### PR DESCRIPTION
Clean up